### PR TITLE
perf(*): parse the scroll trigger expression only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Infinite scrolling directive
+
+## Usage
+
+```
+<ul infinite-scroll="page.loadMore()">
+	<li ng-repeat="item in page.list">
+		...
+	</li>
+</ul>
+```
+
+## Using a different container
+
+One of `window`, `document` or a css selector:
+
+```
+<ul infinite-scroll="page.loadMore()" infinite-scroll-container="window">
+	<li ng-repeat="item in page.list">
+		...
+	</li>
+</ul>
+```

--- a/ng-labs-infiniteScroll.js
+++ b/ng-labs-infiniteScroll.js
@@ -27,7 +27,7 @@ angular.module('labs.infiniteScroll', []).directive('infiniteScroll', [
 
 				fetchItems = (function() {
 					return $parse(attrs.infiniteScroll).bind(null, scope);
-				});
+				})();
 
 				handler = function() {
 					var viewBottom = elem.scrollTop() + elem.height();


### PR DESCRIPTION
- Avoids the parsing of trigger expression every time the event is fired.
- Adds support to infinite-scroll-container attribute
- Add README file
